### PR TITLE
Add in memory reading of message bodies

### DIFF
--- a/MsgViewer/ViewerForm.cs
+++ b/MsgViewer/ViewerForm.cs
@@ -182,6 +182,13 @@ namespace MsgViewer
                 _tempFolders.Add(tempFolder);
 
                 var msgReader = new Reader();
+                
+                // Use this, if you want to extract the code in memory
+                // using (var streamReader = new StreamReader(fileName))
+                // {
+                //     string _body = msgReader.ExtractMsgEmailBody(streamReader.BaseStream, true);
+                // }
+
                 var files = msgReader.ExtractToFolder(fileName, tempFolder, genereateHyperlinksToolStripMenuItem.Checked);
                 var error = msgReader.GetErrorMessage();
 


### PR DESCRIPTION
Add the possibility to extract the message body without saving any files on the disk:

For example:
```csharp
                MsgReader.Reader reader = new MsgReader.Reader();
                string body = reader.ExtractMsgEmailBody(new MemoryStream(Blob), false);

                browserControl.NavigateToString(body);
```