### PR TITLE
Add optional flag to include/exclude a header-table from the extracted body of a mail-message.

### DIFF
--- a/MsgViewer/ViewerForm.Designer.cs
+++ b/MsgViewer/ViewerForm.Designer.cs
@@ -100,6 +100,7 @@
             this.FilesListBox.Name = "FilesListBox";
             this.FilesListBox.Size = new System.Drawing.Size(1038, 129);
             this.FilesListBox.TabIndex = 17;
+            this.FilesListBox.DoubleClick += new System.EventHandler(this.FilesListBox_DoubleClick);
             // 
             // label1
             // 

--- a/MsgViewer/ViewerForm.cs
+++ b/MsgViewer/ViewerForm.cs
@@ -27,6 +27,9 @@ using MsgViewer.Properties;
 
 namespace MsgViewer
 {
+    using System.Diagnostics;
+    using MsgReader.Outlook;
+
     public partial class ViewerForm : Form
     {
         #region Fields
@@ -196,7 +199,15 @@ namespace MsgViewer
                 //     string _body = msgReader.ExtractMsgEmailBody(streamReader.BaseStream, true, "text/html; charset=utf-8");
                 // }
 
-                var files = msgReader.ExtractToFolder(fileName, tempFolder, genereateHyperlinksToolStripMenuItem.Checked);
+                var files = msgReader.ExtractToFolder(
+                    fileName, 
+                    tempFolder, 
+                    genereateHyperlinksToolStripMenuItem.Checked, 
+                    withHeaderTable: true /* set this flag to false, if you don't want a from/to/bcc/... table included in your mailmessage */);
+                
+                // Use this, if you want to display a header table elsewhere but not in the webbrowser
+                // var header = msgReader.ExtractMsgEmailHeader(new Storage.Message(fileName), true);
+
                 var error = msgReader.GetErrorMessage();
 
                 if (!string.IsNullOrEmpty(error))
@@ -291,5 +302,25 @@ namespace MsgViewer
             }
         }
         #endregion
+
+        private void FilesListBox_DoubleClick(object sender, EventArgs e)
+        {
+            if (this.FilesListBox.Items.Count > 0)
+            {
+                var file = this.FilesListBox.SelectedItem as string;
+                if (!string.IsNullOrEmpty(file) && File.Exists(file))
+                {
+                    var fileInfo = new FileInfo(file);
+                    if (fileInfo.Extension?.ToLowerInvariant() == ".msg")
+                    {
+                        Process.Start(Application.ExecutablePath, file);
+                    }
+                    else
+                    {
+                        Process.Start(file);
+                    }
+                }
+            }
+        }
     }
 }

--- a/MsgViewer/ViewerForm.resx
+++ b/MsgViewer/ViewerForm.resx
@@ -127,7 +127,7 @@
   <data name="openToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAHYcAAB2HAY/l8WUAAAJHSURBVDhPxZBdSNNhFMb/F110ZZEVhVBgeeHNICiiuggp
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAJHSURBVDhPxZBdSNNhFMb/F110ZZEVhVBgeeHNICiiuggp
         olAUyyxI0oSaH1QYC3N+tKnp5ubm1JUua5uuqdNKMwr7kApFItTUkWZqVhSVYmao5Nevvy7UoYR3HXh4
         4XCe33nOKyy3lAY7l9RWMo0O/raWXxEyo5spVYTNvOGyfIRPfW+ptOkXqaPl6T83hcRmExSdgzAz3NVm
         YWyoYla/B+1M9JtxWLPpaH22JORIjI6gKAMB0jyEimIdo4OlbuaprwVMOOMovammpDADc34qppwUrmnl
@@ -143,7 +143,7 @@
   <data name="printToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAHYcAAB2HAY/l8WUAAAIpSURBVDhPtZL/T1JRGMb5p1itrVZbbRpqZbawnBENV1I0
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIpSURBVDhPtZL/T1JRGMb5p1itrVZbbRpqZbawnBENV1I0
         jGlByTSyJTXJwq2oKZQb1KAv6JCYWSxvBrkkZUq4CeQEiRABFeLL072Xa0zRra31bO8v57zP5znnPYf1
         X+TxhWF6O7VtGYcnwbSWijKPOLzYrPSvLPwLS3huGUMlT7o9wGD9grVUBj+icdid03S9tDmgNxNwTgVQ
         J+rA8XNtWwM+uuZATMwxmQVRycuJFNyzIRitDlScugKzjSgFRGJJaIwEsrk8AsHIhnSL/Ssck37UNipQ
@@ -161,7 +161,7 @@
   <data name="PrintButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAHYcAAB2HAY/l8WUAAAIpSURBVDhPtZL/T1JRGMb5p1itrVZbbRpqZbawnBENV1I0
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIpSURBVDhPtZL/T1JRGMb5p1itrVZbbRpqZbawnBENV1I0
         jGlByTSyJTXJwq2oKZQb1KAv6JCYWSxvBrkkZUq4CeQEiRABFeLL072Xa0zRra31bO8v57zP5znnPYf1
         X+TxhWF6O7VtGYcnwbSWijKPOLzYrPSvLPwLS3huGUMlT7o9wGD9grVUBj+icdid03S9tDmgNxNwTgVQ
         J+rA8XNtWwM+uuZATMwxmQVRycuJFNyzIRitDlScugKzjSgFRGJJaIwEsrk8AsHIhnSL/Ssck37UNipQ
@@ -176,7 +176,7 @@
   <data name="SaveAsTextButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAHYcAAB2HAY/l8WUAAAPVSURBVFhHzZbfS5NhFMe9jYq6MaKroPt+XEXRH9BlUkEE
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAPVSURBVFhHzZbfS5NhFMe9jYq6MaKroPt+XEXRH9BlUkEE
         UVCB0E0UdBVlhGARFJVoZmr4e6am5tTlmNZ0zmzpnLrJnLpMl1l40f2p79POw9mz9323oIsOfDjvxrt9
         v9/znsdZkKsa/cVU7z+tqBk6RZX9RYq6vluUvuXf1ebmT2LiyQiVvtpPT7vO0YWn2+nMg610onQLFd3d
         RuWNt2gt9V3fy6x/28y6Tn39oa7RmbRcdvGHIf5k4CBVuE+SL1JOJa1H6PyjHcpEleu2+hJTSHbGShzG


### PR DESCRIPTION
Update example project MsgViewer to reflect this change. Add double-click event to the attachments-box of the example project.