### PR TITLE
Use SystemFonts.DefaultFont instead of Control.DefaultFont

### DIFF
--- a/MsgReaderCore/Rtf/DocumentFormatInfo.cs
+++ b/MsgReaderCore/Rtf/DocumentFormatInfo.cs
@@ -272,7 +272,7 @@ namespace MsgReader.Rtf
             Italic = false;
             Bold = false;
             FontSize = 12f;
-            FontName = System.Windows.Forms.Control.DefaultFont.Name;
+            FontName = SystemFonts.DefaultFont.Name;
             Align = RtfAlignment.Left;
             SpacingAfter = 0;
             SpacingBefore = 0;
@@ -384,7 +384,7 @@ namespace MsgReader.Rtf
         #region ResetText
         public void ResetText()
         {
-            FontName = System.Windows.Forms.Control.DefaultFont.Name;
+            FontName = SystemFonts.DefaultFont.Name;
             Bold = false;
             Italic = false;
             Underline = false;
@@ -442,7 +442,7 @@ namespace MsgReader.Rtf
             SpacingBefore = 0;
             SpacingAfter = 0;
             Align = 0;
-            FontName = System.Windows.Forms.Control.DefaultFont.Name;
+            FontName = SystemFonts.DefaultFont.Name;
             FontSize = 12;
             Bold = false;
             Italic = false;

--- a/MsgReaderCore/Rtf/DocumentWriter.cs
+++ b/MsgReaderCore/Rtf/DocumentWriter.cs
@@ -266,7 +266,7 @@ namespace MsgReader.Rtf
                 Info.Clear();
                 FontTable.Clear();
                 ColorTable.Clear();
-                FontTable.Add(Control.DefaultFont.Name);
+                FontTable.Add(SystemFonts.DefaultFont.Name);
             }
             else
             {

--- a/MsgReaderCore/Rtf/DomDocument.cs
+++ b/MsgReaderCore/Rtf/DomDocument.cs
@@ -32,7 +32,7 @@ namespace MsgReader.Rtf
 		/// <summary>
 		/// default font name
 		/// </summary>
-		private static readonly string DefaultFontName = Control.DefaultFont.Name;
+		private static readonly string DefaultFontName = SystemFonts.DefaultFont.Name;
 		// ReSharper disable once NotAccessedField.Local
 		private int _listTextFlag;
 		private DocumentFormatInfo _paragraphFormat;
@@ -2714,7 +2714,7 @@ namespace MsgReader.Rtf
 							index = reader.Parameter;
 						else if (reader.Keyword == "fnil")
 						{
-							name = Control.DefaultFont.Name;
+							name = SystemFonts.DefaultFont.Name;
 							nilFlag = true;
 						}
 						else if (reader.Keyword == Consts.Fcharset)
@@ -2745,7 +2745,7 @@ namespace MsgReader.Rtf
 
 						name = name.Trim();
 						if (string.IsNullOrEmpty(name))
-							name = Control.DefaultFont.Name;
+							name = SystemFonts.DefaultFont.Name;
 
 						var font = new Font(index, name) { Charset = charset, NilFlag = nilFlag };
 						FontTable.Add(font);


### PR DESCRIPTION
`Control.DefaultFont` uses `SystemFonts.DefaultFont` under the hood
https://referencesource.microsoft.com/#System.Windows.Forms/winforms/Managed/System/WinForms/Control.cs,2142