### PR TITLE
Remove eager evaluation when a quote is encountered.

### DIFF
--- a/MsgReaderCore/Rtf/Lex.cs
+++ b/MsgReaderCore/Rtf/Lex.cs
@@ -102,25 +102,6 @@ namespace MsgReader.Rtf
             var c = _reader.Read();
             var peekChar = _reader.Peek();
 
-            if (c == '\"' && peekChar != '\\') // || peekChar != '{' || peekChar != 13))
-            {
-                var stringBuilder = new StringBuilder();
-
-                while (true)
-                {
-                    c = _reader.Read();
-                    if (c < 0 || c == '\"' || c == '\r' || c == '\n')
-                        break;
-
-                    stringBuilder.Append((char) c);
-                }
-
-                token.Type = RtfTokenType.Text;
-                token.Key = stringBuilder.ToString();
-                
-                return token;
-            }
-
             while (c == '\r'
                    || c == '\n'
                    || c == '\t'


### PR DESCRIPTION
Hello,

I'm a software developer at Microsoft, working on OneDrive and SharePoint.  We noticed a bug in your component around parsing RTF.  Particularly, there's a block of code in Lex.cs that looks like it's eagerly consuming tokens after quote characters, under the assumption that everything until the next quote is text.  However, this often results in RTF control sequences being written out into the resulting HTML.  

For example:

{\*\htmltag148 <span lang=KO style='font-size:10.0pt;font-family:"\'b8\'bc\'c0\'ba \'b0\'ed\'b5\'f1"'>}\htmlrtf {\lang1042 \f4 \htmlrtf0 ...

gets written out as 

<span lang=KO style='font-size:10.0pt;font-family:"맑은 고딕'>}\htmlrtf {\lang1042 \f4 \htmlrtf0 

because eager evaluation kicks in at the second " character.  

Everything seems to work fine when that if block is removed.  

Regards,

Carl Hirschman
Senior Software Engineer
Microsoft