### PR TITLE
PR_PRIMARY_SEND_ACCT - currently returns all data in email record, when only really want the smtp address

### DIFF
--- a/MsgReaderCore/Outlook/Message.cs
+++ b/MsgReaderCore/Outlook/Message.cs
@@ -1761,10 +1761,11 @@ namespace MsgReader.Outlook
                 // PR_PRIMARY_SEND_ACCT can contain the smtp address of an exchange account
                 if (string.IsNullOrEmpty(tempEmail) || tempEmail.IndexOf("@", StringComparison.Ordinal) < 0)
                 {
+                    var testSeparator = "\u0001";
                     var testEmail = GetMapiPropertyString(MapiTags.PR_PRIMARY_SEND_ACCT);
-                    if(!string.IsNullOrEmpty(testEmail) && testEmail.IndexOf("\u0001", StringComparison.Ordinal) > 0)
+                    if(!string.IsNullOrEmpty(testEmail) && testEmail.IndexOf(testSeparator, StringComparison.Ordinal) > 0)
                     {
-                        testEmail = testEmail.Substring(testEmail.IndexOf("\u0001", StringComparison.Ordinal));
+                        testEmail = testEmail.Substring(testEmail.LastIndexOf(testSeparator, StringComparison.Ordinal) + testSeparator.Length);
                         if (string.IsNullOrEmpty(testEmail) || testEmail.LastIndexOf("@", StringComparison.Ordinal) > 0)
                             tempEmail = testEmail;
                     }
@@ -1773,10 +1774,11 @@ namespace MsgReader.Outlook
 
                 //if (string.IsNullOrEmpty(tempEmail) || tempEmail.IndexOf("@", StringComparison.Ordinal) < 0)
                 //{
+                //    var testSeparator = "\u0001";
                 //    var testEmail = GetMapiPropertyString(MapiTags.PR_NEXT_SEND_ACCT);
-                //    if (!string.IsNullOrEmpty(testEmail) && testEmail.IndexOf("\u0001", StringComparison.Ordinal) > 0)
+                //    if (!string.IsNullOrEmpty(testEmail) && testEmail.IndexOf(testSeparator, StringComparison.Ordinal) > 0)
                 //    {
-                //        testEmail = testEmail.Substring(testEmail.IndexOf("\u0001", StringComparison.Ordinal));
+                //        testEmail = testEmail.Substring(testEmail.LastIndexOf(testSeparator, StringComparison.Ordinal) + testSeparator.Length);
                 //        if (string.IsNullOrEmpty(testEmail) || testEmail.LastIndexOf("@", StringComparison.Ordinal) > 0)
                 //            tempEmail = testEmail;
                 //    }

--- a/MsgViewer/ViewerForm.cs
+++ b/MsgViewer/ViewerForm.cs
@@ -191,6 +191,9 @@ namespace MsgViewer
 
                 var msgReader = new Reader();
 
+                var aa = new MsgReader.Outlook.Storage.Message(fileName);
+                aa.Dispose();
+
                 // Use this, if you want to extract the code in memory
                 // using (var streamReader = new StreamReader(fileName))
                 // {

--- a/MsgViewer/ViewerForm.cs
+++ b/MsgViewer/ViewerForm.cs
@@ -191,8 +191,6 @@ namespace MsgViewer
 
                 var msgReader = new Reader();
 
-                var aa = new MsgReader.Outlook.Storage.Message(fileName);
-                aa.Dispose();
 
                 // Use this, if you want to extract the code in memory
                 // using (var streamReader = new StreamReader(fileName))


### PR DESCRIPTION
The smtp address is the last part of the entry delimited but \u0001. currently entire entry is returned if it contains @, but should only check and return the last portion.
Sorry for any inconvenience.
