### PR TITLE
Add additional checks when looking up sender email

### DIFF
--- a/MsgReaderCore/Helpers/EmailAddress.cs
+++ b/MsgReaderCore/Helpers/EmailAddress.cs
@@ -33,6 +33,8 @@ namespace MsgReader.Helpers
     /// </summary>
     internal static class EmailAddress
     {
+        private static readonly Regex EmailRegex = new Regex(@"\w+([-+.]\w+)*@\w+([-.]\w+)*\.\w+([-.]\w+)*", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
         #region IsEmailAddressValid
         /// <summary>
         /// Return true when the E-mail address is valid
@@ -44,12 +46,24 @@ namespace MsgReader.Helpers
             if (string.IsNullOrEmpty(emailAddress))
                 return false;
 
-            var regex = new Regex(@"\w+([-+.]\w+)*@\w+([-.]\w+)*\.\w+([-.]\w+)*", RegexOptions.IgnoreCase);
-            var matches = regex.Matches(emailAddress);
+            var matches = EmailRegex.Matches(emailAddress);
 
             return matches.Count == 1;
         }
         #endregion
+
+        public static string GetValidEmailAddress(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+                return null;
+
+            var matches = EmailRegex.Matches(value);
+
+            if (matches.Count != 1)
+                return null;
+
+            return matches[0].Value;
+        }
 
         #region RemoveSingleQuotes
         /// <summary>

--- a/MsgReaderCore/Outlook/MapiTags.cs
+++ b/MsgReaderCore/Outlook/MapiTags.cs
@@ -1559,6 +1559,11 @@ namespace MsgReader.Outlook
         public const string InternetAccountName = "8580";
 
         /// <summary>
+        /// Unnamed property that may contain the SMTP email address of the sender
+        /// </summary>
+        public const string SenderSmtpAddressAlternate = "5D0A";
+
+        /// <summary>
         /// Contains the code page that is used in HTML when this is added in binary format
         /// </summary>
         public const string PR_CODE_PAGE_ID = "66C3";

--- a/MsgReaderCore/Outlook/Message.cs
+++ b/MsgReaderCore/Outlook/Message.cs
@@ -1745,6 +1745,9 @@ namespace MsgReader.Outlook
                 if (string.IsNullOrEmpty(tempEmail))
                     tempEmail = GetMapiPropertyString(MapiTags.InternetAccountName);
 
+                if (string.IsNullOrEmpty(tempEmail))
+                    tempEmail = GetMapiPropertyString(MapiTags.SenderSmtpAddressAlternate);
+
                 MessageHeader headers = null;
 
                 if (string.IsNullOrEmpty(tempEmail) || tempEmail.IndexOf("@", StringComparison.Ordinal) < 0)

--- a/MsgReaderCore/Outlook/Message.cs
+++ b/MsgReaderCore/Outlook/Message.cs
@@ -1768,9 +1768,7 @@ namespace MsgReader.Outlook
                     var testEmail = GetMapiPropertyString(MapiTags.PR_PRIMARY_SEND_ACCT);
                     if(!string.IsNullOrEmpty(testEmail) && testEmail.IndexOf("\u0001", StringComparison.Ordinal) > 0)
                     {
-                        testEmail = testEmail.Substring(testEmail.IndexOf("\u0001", StringComparison.Ordinal));
-                        if (string.IsNullOrEmpty(testEmail) || testEmail.LastIndexOf("@", StringComparison.Ordinal) > 0)
-                            tempEmail = testEmail;
+                        tempEmail = EmailAddress.GetValidEmailAddress(testEmail);
                     }
                 }
 


### PR DESCRIPTION
In reference to #71, added a check to look in 0x5D0A. I couldn't seem to find any documentation for this nor did Outlook Spy show up any property name so naming the constant was a bit tricky.

Also noticed that the PR_PRIMARY_SEND_ACCT may contain an Exchange FQDN type string and as we're ultimately trying to populate an EmailAddress property, feels preferable to extract out the value using the regex.