### PR TITLE
Workaround for wrong placed chars with codepages like 1252 while reading html from rtf content of a msg

### DIFF
--- a/MsgReaderCore/Rtf/DomDocument.cs
+++ b/MsgReaderCore/Rtf/DomDocument.cs
@@ -3293,7 +3293,15 @@ namespace MsgReader.Rtf
 
             while (reader.ReadToken() != null)
 	        {
-		        switch (reader.Keyword)
+                if (reader.LastToken?.Key == "'" && reader?.Keyword != "'" && hexBuffer != string.Empty && !encoding.IsSingleByte) {
+                    //double byte charset was detected for the last token but only one byte was used so far. 
+                    //This token should carry the second byte but it doesn't.
+                    //Workaround:To display it anyway, we treat it as a single byte char.
+                    var buff = new[] { byte.Parse(hexBuffer, NumberStyles.HexNumber) };
+                    hexBuffer = string.Empty;
+                    stringBuilder.Append(encoding.GetString(buff));
+                }
+                switch (reader.Keyword)
 		        {
                     case Consts.Fonttbl:
                         // Read font table


### PR DESCRIPTION
In some mails with \ansicpg1252 there was the problem, that special chars like \\'E4 ('ä') had been placed at the next appearance of \\' or after the HTML tag. The comitted code fixed this problem for me, but there is certainly a better solution. I am not sure, if special chars in double byte codepages are working properly. I had not the time to test it.