### PR TITLE
Fix issue when an attachment with missing Content ID is considered inline

### DIFF
--- a/MsgReaderCore/Mime/Message.cs
+++ b/MsgReaderCore/Mime/Message.cs
@@ -140,8 +140,11 @@ namespace MsgReader.Mime
 			    {
 			        foreach (var attachment in attachments)
 			        {
-                        if (attachment.IsInline) continue;
-			            var htmlBody = HtmlBody.BodyEncoding.GetString(HtmlBody.Body);
+			            if (attachment.IsInline || attachment.ContentId == null)
+			            {
+			                continue;
+			            }
+                        var htmlBody = HtmlBody.BodyEncoding.GetString(HtmlBody.Body);
 			            attachment.IsInline = htmlBody.Contains($"cid:{attachment.ContentId}");
 			        }
 			    }


### PR DESCRIPTION
When an email has an inline attachment and an attached file (with Content-Disposition: attachment) and the attached file is missing the Content ID, the email html body will match the string `"cid:"` and the attached attachment is set incorrectly to "inline".

Example:

Inline attachment:

```
Content-Type: image/jpeg; name="image001.jpg"
Content-Description: image001.jpg
Content-Disposition: inline; filename="image001.jpg"; size=2954;
	creation-date="Tue, 01 Oct 2019 20:00:13 GMT";
	modification-date="Tue, 01 Oct 2019 20:00:13 GMT"
Content-ID: <image001.jpg@01D57867.BA7E4660>
Content-Transfer-Encoding: base64
```

Attachment:

```
Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;
	name="10-1-2019.xlsx"
Content-Description: 10-1-2019.xlsx
Content-Disposition: attachment; filename="10-1-2019.xlsx"; size=28621;
	creation-date="Tue, 01 Oct 2019 19:51:17 GMT";
	modification-date="Tue, 01 Oct 2019 19:51:17 GMT"
Content-Transfer-Encoding: base64
```


Html Body:

`cid:image001.jpg@01D57867.BA7E4660`
