### PR TITLE
fixed Storage finalizers behavior. 

### DIFF
--- a/MsgReaderCore/Outlook/Storage.cs
+++ b/MsgReaderCore/Outlook/Storage.cs
@@ -175,7 +175,7 @@ namespace MsgReader.Outlook
         /// </summary>
         ~Storage()
         {
-            Dispose();
+            Dispose(false);
         }
         #endregion
 
@@ -527,9 +527,17 @@ namespace MsgReader.Outlook
         /// </summary>
         public void Dispose()
         {
-            if (_compoundFile == null) return;
-            _compoundFile.Close();
-            _compoundFile = null;
+            Dispose(true);
+        }
+
+        public virtual void Dispose(bool isDispoing)
+        {
+            if (isDispoing)
+            {
+                if (_compoundFile == null) return;
+                _compoundFile.Close();
+                _compoundFile = null;
+            }
         }
         #endregion
     }

--- a/MsgReaderTests/ExternalResourcesTests.cs
+++ b/MsgReaderTests/ExternalResourcesTests.cs
@@ -11,23 +11,23 @@ namespace MsgReaderTests
         [DeploymentItem("SampleFiles", "SampleFiles")]
         public void StorageFinaizerBehaviourTest()
         {
-            int? SampleOperationWithDotNetsStreamReadersFinalizer(System.IO.Stream stream)
+            int? SampleOperationWithDotNetsStreamReaders(System.IO.Stream stream)
             {
-                //We will not call dispose here so the finalizer should not kill the extern stream
+                //We will not call dispose here to keep the extern stream alive
                 var reference = new System.IO.StreamReader(stream);
                 return reference.Read();
             }
 
-            int? OperationWithMsgReaderFinalizer(System.IO.Stream stream)
+            int? OperationWithMsgReader(System.IO.Stream stream)
             {
-                //We will not call dispose here so the finalizer should not kill the extern stream
+                //We will not call dispose here to keep the extern stream alive
                 var reference = new Storage.Message(stream);
                 return reference.Size;
             }
 
             using (var inputStream = System.IO.File.Open(System.IO.Path.Combine("SampleFiles", "EmailWithAttachments.msg"), System.IO.FileMode.Open, System.IO.FileAccess.Read))
             {
-                SampleOperationWithDotNetsStreamReadersFinalizer(inputStream);
+                SampleOperationWithDotNetsStreamReaders(inputStream);
                 GC.Collect(0, GCCollectionMode.Forced);
                 GC.WaitForPendingFinalizers();
                 try
@@ -39,7 +39,7 @@ namespace MsgReaderTests
                     Assert.Fail("The stream should not be disposed now");
                 }
 
-                OperationWithMsgReaderFinalizer(inputStream);
+                OperationWithMsgReader(inputStream);
                 GC.Collect(0, GCCollectionMode.Forced);
                 GC.WaitForPendingFinalizers();
                 try

--- a/MsgReaderTests/ExternalResourcesTests.cs
+++ b/MsgReaderTests/ExternalResourcesTests.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MsgReader.Outlook;
+
+namespace MsgReaderTests
+{
+    [TestClass]
+    public class ExternalResourcesTests
+    {
+        [TestMethod]
+        [DeploymentItem("SampleFiles", "SampleFiles")]
+        public void StorageFinaizerBehaviourTest()
+        {
+            int? SampleOperationWithDotNetsStreamReadersFinalizer(System.IO.Stream stream)
+            {
+                //We will not call dispose here so the finalizer should not kill the extern stream
+                var reference = new System.IO.StreamReader(stream);
+                return reference.Read();
+            }
+
+            int? OperationWithMsgReaderFinalizer(System.IO.Stream stream)
+            {
+                //We will not call dispose here so the finalizer should not kill the extern stream
+                var reference = new Storage.Message(stream);
+                return reference.Size;
+            }
+
+            using (var inputStream = System.IO.File.Open(System.IO.Path.Combine("SampleFiles", "EmailWithAttachments.msg"), System.IO.FileMode.Open, System.IO.FileAccess.Read))
+            {
+                SampleOperationWithDotNetsStreamReadersFinalizer(inputStream);
+                GC.Collect(0, GCCollectionMode.Forced);
+                GC.WaitForPendingFinalizers();
+                try
+                {
+                    inputStream.Seek(0, System.IO.SeekOrigin.Begin);
+                }
+                catch (ObjectDisposedException)
+                {
+                    Assert.Fail("The stream should not be disposed now");
+                }
+
+                OperationWithMsgReaderFinalizer(inputStream);
+                GC.Collect(0, GCCollectionMode.Forced);
+                GC.WaitForPendingFinalizers();
+                try
+                {
+                    inputStream.Seek(0, System.IO.SeekOrigin.Begin);
+                }
+                catch (ObjectDisposedException)
+                {
+                    Assert.Fail("The stream should not be disposed now");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
So extern managed streams will not be disposed by the GC at "random" times anymore.