### PR TITLE
If MSG is of type "unknown" guess

### DIFF
--- a/MsgReaderCore/Reader.cs
+++ b/MsgReaderCore/Reader.cs
@@ -397,6 +397,21 @@ namespace MsgReader
 
                         Logger.WriteToLog($"MSG file has the type '{messageType.ToString()}'");
 
+                        if (messageType == MessageType.Unknown)
+                        {
+                            // Make a guess - Email ?
+                            if ((!string.IsNullOrEmpty(message.BodyHtml) || !string.IsNullOrEmpty(message.BodyRtf) || !string.IsNullOrEmpty(message.BodyText)) &&
+                                ((message.Recipients != null && message.Recipients.Count > 0) ||
+                                 (message.Sender != null && (!string.IsNullOrEmpty(message.Sender.DisplayName) || !string.IsNullOrEmpty(message.Sender.Email)))
+                                )
+                            )
+                            {
+                                messageType = MessageType.Email;
+
+                                Logger.WriteToLog($"By best guess the MSG file has the type '{messageType.ToString()}'");
+                            }
+                        }
+
                         switch (messageType)
                         {
                             case MessageType.Email:


### PR DESCRIPTION
If MSG is of type "unknown" guess it to be an email if it has a body and a sender or receipients.

I encountered a few e-mails which always resulted in message.type = Unknown.

Thus, I suggest that in case the message has a body and (sender or receipients) it is safe to handle it as an email.