### PR TITLE
Do not show representative if same as sender

### DIFF
--- a/MsgReaderCore/Outlook/Message.cs
+++ b/MsgReaderCore/Outlook/Message.cs
@@ -1879,9 +1879,12 @@ namespace MsgReader.Outlook
 
                 if (SenderRepresenting != null)
                 {
-                    representingEmailAddress = SenderRepresenting.Email;
-                    representingDisplayName = SenderRepresenting.DisplayName;
-                    representingAddressType = SenderRepresenting.AddressType;
+                    if (displayName != SenderRepresenting.DisplayName)
+                    {
+                        representingEmailAddress = SenderRepresenting.Email;
+                        representingDisplayName = SenderRepresenting.DisplayName;
+                        representingAddressType = SenderRepresenting.AddressType;
+                    }
                 }
 
                 if (html)


### PR DESCRIPTION
Do not show representative if same as sender.

Some of my users were annoyed that on their system they are always also the representative of the email.

If sender and representative is the same, not necessary to show the representative.