### PR TITLE
Hotfix: Fixed parse error on outlook exchange sender address

### DIFF
--- a/MsgReaderCore/Outlook/Message.cs
+++ b/MsgReaderCore/Outlook/Message.cs
@@ -1863,10 +1863,35 @@ namespace MsgReader.Outlook
                 if (string.IsNullOrEmpty(tempEmail) || tempEmail.IndexOf("@", StringComparison.Ordinal) < 0)
                 {
                     var testEmail = GetMapiPropertyString(MapiTags.PR_PRIMARY_SEND_ACCT);
-                    if(!string.IsNullOrEmpty(testEmail) && testEmail.IndexOf("\u0001", StringComparison.Ordinal) > 0)
+
+                    var i = testEmail.IndexOf("\u0001", StringComparison.Ordinal);
+                    if(i > 0)
                     {
+                        testEmail = testEmail.Substring(i);
                         tempEmail = EmailAddress.GetValidEmailAddress(testEmail);
+                        if (tempEmail == null)
+                        {
+                            i = testEmail.IndexOf("\u0001", 6, StringComparison.Ordinal);
+                            if (i > 0)
+                            {
+                                tempEmail = EmailAddress.GetValidEmailAddress(testEmail.Substring(i));
+                            }
+                        }
                     }
+
+                    //while (!string.IsNullOrEmpty(testEmail))
+                    //{
+                    //    var i = testEmail.IndexOf("\u0001", StringComparison.Ordinal);
+                    //    if(i > 0)
+                    //    {
+                    //        testEmail = testEmail.Substring(i);
+                    //        tempEmail = EmailAddress.GetValidEmailAddress(testEmail);
+                    //        if (tempEmail != null) break;
+                    //    } else
+                    //    {
+                    //        break;
+                    //    }
+                    //}
                 }
 
                 tempEmail = EmailAddress.RemoveSingleQuotes(tempEmail);


### PR DESCRIPTION
If u try to parse an exchange server transmitted msg, so the sender email wasn't parsed correctly. There are two signs of "\u0001" in the sender string. 

So i implemented another try to get the sender email.

br.