### PR TITLE
Invert the not null condition with the BodyHtml

### DIFF
--- a/MsgReaderCore/Outlook/Message.cs
+++ b/MsgReaderCore/Outlook/Message.cs
@@ -1012,7 +1012,7 @@ namespace MsgReader.Outlook
 
                     var text = string.Empty;
 
-                    if (_bodyHtml == null)
+                    if (_bodyHtml != null)
                     {
                         // Force the loading of the HTML
                         text = BodyHtml;


### PR DESCRIPTION
Hi,

We a an NullReferenceException when then mail is in RTF and not HTML. The condition on null check is inverted.

![image](https://user-images.githubusercontent.com/11708704/180217456-9f957c80-2d70-4866-9cff-7fbabb361471.png)
 