### PR TITLE
Fix wrong RTF parsing on a certain text token with fewer white spaces

### DIFF
--- a/MsgReaderCore/MsgReader.csproj
+++ b/MsgReaderCore/MsgReader.csproj
@@ -92,4 +92,10 @@ The EML reader supports MIME 1.0 encoded files.</Description>
 		</EmbeddedResource>
 	</ItemGroup>
 
+	<ItemGroup>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+			<_Parameter1>MsgReaderTests, PublicKey=00240000048000009400000006020000002400005253413100040000010001001df6864f858088dc1a10e499c307b6d9d0e447dd62b70ea57b1ffbeedf7ac83f811ef8c2848d6e82ec49e21e94e5fc5f52eb67c1f1e2cea8116695d26ff0db7792f635a59d47b048898f584e94fa781376d3460c070cff31d820bd39e270472c0661f8aecb11b450d89ee827171a725828a8f712fbece052a71db97f31c006c8</_Parameter1>
+		</AssemblyAttribute>
+	</ItemGroup>
+
 </Project>

--- a/MsgReaderCore/Rtf/Document.cs
+++ b/MsgReaderCore/Rtf/Document.cs
@@ -829,12 +829,12 @@ internal class Document
                     }
 
                     hexBuffer = string.Empty;
+                }
 
-                    if (reader.TokenType == RtfTokenType.Text)
-                    {
-                        stringBuilder.Append(reader.Keyword);
-                        continue;
-                    }
+                if (reader.TokenType == RtfTokenType.Text)
+                {
+                    stringBuilder.Append(reader.Keyword);
+                    continue;
                 }
 
                 switch (reader.Keyword)

--- a/MsgReaderTests/MsgReaderTests.csproj
+++ b/MsgReaderTests/MsgReaderTests.csproj
@@ -8,6 +8,9 @@
     <AssemblyVersion>3.3.0.0</AssemblyVersion>
 
     <FileVersion>1.3.0.0</FileVersion>
+
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>../MsgReaderCore/MSGReader.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MsgReaderTests/RtfDocumentTests.cs
+++ b/MsgReaderTests/RtfDocumentTests.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MsgReader.Rtf;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace MsgReaderTests
+{
+    [TestClass]
+    public class RtfDocumentTests
+    {
+        [TestMethod]
+        public void ParseTextF1()
+        {
+            var rtfDomDocument = new Document();
+            rtfDomDocument.ParseRtfText("{\\rtf1\\ansi\\ansicpg1252\\fromhtml1\\htmlrtf{\\lang1030 \\htmlrtf0  f\\'f8}}");
+            Assert.AreEqual(expected: " fø", actual: rtfDomDocument.HtmlContent, ignoreCase: false);
+        }
+
+        [TestMethod]
+        public void ParseTextF2()
+        {
+            var rtfDomDocument = new Document();
+            rtfDomDocument.ParseRtfText("{\\rtf1\\ansi\\ansicpg1252\\fromhtml1\\htmlrtf{\\lang1030 \\htmlrtf0 f\\'f8}}");
+            Assert.AreEqual(expected: "fø", actual: rtfDomDocument.HtmlContent, ignoreCase: false);
+        }
+    }
+}


### PR DESCRIPTION
Fix #332 