### PR TITLE
Added optional FileAccess on Mime to load read-only eml files.

### DIFF
--- a/MsgReaderCore/Mime/Message.cs
+++ b/MsgReaderCore/Mime/Message.cs
@@ -367,7 +367,7 @@ public class Message
     /// <summary>
     ///     Save this <see cref="Message" /> to a file.<br />
     ///     <br />
-    ///     Can be loaded at a later time using the <see cref="Load(FileInfo)" /> method.
+    ///     Can be loaded at a later time using the <see cref="Load(FileInfo, FileAccess)" /> method.
     /// </summary>
     /// <param name="file">The File location to save the <see cref="Message" /> to. Existent files will be overwritten.</param>
     /// <exception cref="ArgumentNullException">If <paramref name="file" /> is <see langword="null" /></exception>
@@ -402,11 +402,12 @@ public class Message
     ///     Loads a <see cref="Message" /> from a file containing a raw email.
     /// </summary>
     /// <param name="file">The File location to load the <see cref="Message" /> from. The file must exist.</param>
+    /// <param name="fileAccess">Optional file access. Default read/write. Required for read-only files.</param>
     /// <exception cref="ArgumentNullException">If <paramref name="file" /> is <see langword="null" /></exception>
     /// <exception cref="FileNotFoundException">If <paramref name="file" /> does not exist</exception>
     /// <exception>Other exceptions relevant to a <see cref="FileStream" /> might be thrown as well</exception>
     /// <returns>A <see cref="Message" /> with the content loaded from the <paramref name="file" /></returns>
-    public static Message Load(FileInfo file)
+    public static Message Load(FileInfo file, FileAccess fileAccess = FileAccess.ReadWrite)
     {
         Logger.WriteToLog($"Loading EML file from '{file.FullName}'");
 
@@ -416,7 +417,7 @@ public class Message
         if (!file.Exists)
             throw new FileNotFoundException("Cannot load message from non-existent file", file.FullName);
 
-        using var fileStream = new FileStream(file.FullName, FileMode.Open);
+        using var fileStream = new FileStream(file.FullName, FileMode.Open, fileAccess);
         return Load(fileStream);
     }
 

--- a/MsgReaderCore/MsgReader.xml
+++ b/MsgReaderCore/MsgReader.xml
@@ -2382,7 +2382,7 @@
             <summary>
                 Save this <see cref="T:MsgReader.Mime.Message" /> to a file.<br />
                 <br />
-                Can be loaded at a later time using the <see cref="M:MsgReader.Mime.Message.Load(System.IO.FileInfo)" /> method.
+                Can be loaded at a later time using the <see cref="M:MsgReader.Mime.Message.Load(System.IO.FileInfo,System.IO.FileAccess)" /> method.
             </summary>
             <param name="file">The File location to save the <see cref="T:MsgReader.Mime.Message" /> to. Existent files will be overwritten.</param>
             <exception cref="T:System.ArgumentNullException">If <paramref name="file" /> is <see langword="null" /></exception>
@@ -2396,11 +2396,12 @@
             <exception cref="T:System.ArgumentNullException">If <paramref name="messageStream" /> is <see langword="null" /></exception>
             <exception>Other exceptions relevant to Stream.Write might be thrown as well</exception>
         </member>
-        <member name="M:MsgReader.Mime.Message.Load(System.IO.FileInfo)">
+        <member name="M:MsgReader.Mime.Message.Load(System.IO.FileInfo,System.IO.FileAccess)">
             <summary>
                 Loads a <see cref="T:MsgReader.Mime.Message" /> from a file containing a raw email.
             </summary>
             <param name="file">The File location to load the <see cref="T:MsgReader.Mime.Message" /> from. The file must exist.</param>
+            <param name="fileAccess">Optional file access. Default read/write. Required for read-only files.</param>
             <exception cref="T:System.ArgumentNullException">If <paramref name="file" /> is <see langword="null" /></exception>
             <exception cref="T:System.IO.FileNotFoundException">If <paramref name="file" /> does not exist</exception>
             <exception>Other exceptions relevant to a <see cref="T:System.IO.FileStream" /> might be thrown as well</exception>


### PR DESCRIPTION
Following the Readme.md instructions on "Read properties from an Outlook (eml) message", the method MsgReader.Mime.Message.Load fails on read-only eml-files, due to the FileStream constructor used, see remarks on:
https://learn.microsoft.com/en-us/dotnet/api/system.io.filestream.-ctor?view=net-7.0#system-io-filestream-ctor(system-string-system-io-filemode)
An optional FileAccess parameter with default read-write solves the issue without breaking compatibility.
The problem was encountered on a read-only archive of eml messages secured by NTFS file permissions.