### PR TITLE
fixing reactions

### DIFF
--- a/MsgReaderCore/Outlook/Reaction.cs
+++ b/MsgReaderCore/Outlook/Reaction.cs
@@ -245,7 +245,9 @@ namespace MsgReader.Outlook
                 }
             }
 
-            return BitConverter.ToInt32(result.ToArray(), 0);
+            return result.Count == 0
+                ? 0
+                : BitConverter.ToInt32(result.ToArray(), 0);
         }
 
         /// <summary>

--- a/MsgReaderCore/Outlook/Reaction.cs
+++ b/MsgReaderCore/Outlook/Reaction.cs
@@ -221,8 +221,8 @@ namespace MsgReader.Outlook
         // ReSharper disable once UnusedMethodReturnValue.Local
         private static int ParseReactionsCount(BinaryReader reader)
         {
-            var result = new List<byte>();
             var foundEndOfLine = false;
+            var count = 0;
 
             while (!foundEndOfLine)
             {
@@ -231,8 +231,7 @@ namespace MsgReader.Outlook
                 switch ((char)ch)
                 {
                     case '=':
-                        reader.ReadUInt16();
-                        result.Clear();
+                        count += reader.ReadUInt16();
                         break;
 
                     case RecordSeparator:
@@ -240,14 +239,11 @@ namespace MsgReader.Outlook
                         break;
 
                     default:
-                        result.Add(ch);
                         break;
                 }
             }
 
-            return result.Count == 0
-                ? 0
-                : BitConverter.ToInt32(result.ToArray(), 0);
+            return count;
         }
 
         /// <summary>

--- a/MsgReaderTests/ReactionTests.cs
+++ b/MsgReaderTests/ReactionTests.cs
@@ -15,10 +15,10 @@ namespace MsgReaderTests
     [TestClass]
     public class ReactionTests
     {
-        private const string ReactionSummaryRowText = "test2, test2@readreceipts.onmicrosoft.com, heart, 10/19/2023 10:36:00 PM";
-        private const string ReactionSummaryLabelText = "ReactionsSummary";
-        private const string OwnerReactionHistoryRowText = "test2, test2@readreceipts.onmicrosoft.com, [removed], 10/19/2023 10:35:25 PM";
-        private const string OwnerReactionHistoryLabelText = "OwnerReactionHistory";
+        private const string ReactionSummaryRowText = "test2, test2@readreceipts.onmicrosoft.com, heart, 10/19/2023 22:36:00";
+        private const string ReactionSummaryLabelText = "Reactions summary";
+        private const string OwnerReactionHistoryRowText = "test2, test2@readreceipts.onmicrosoft.com, [removed], 10/19/2023 22:35:25";
+        private const string OwnerReactionHistoryLabelText = "Owner reaction history";
 
         [TestMethod]
         public void Reactions_ExtractMsgEmailBody()


### PR DESCRIPTION
This PR adds a check to mitigate an index out of bounds exception that arose when we upgraded to 5.5.1. 

This change + modifications to the reaction test suite (due to reaction localization changes) now have the reaction tests passing. Could you please verify that these tests pass for future?  

Thank you!
Matthew