### PR TITLE
Fix HtmlToText stack overflow error when converting HTML comments

### DIFF
--- a/MsgViewer/Helpers/HtmlToText.cs
+++ b/MsgViewer/Helpers/HtmlToText.cs
@@ -302,16 +302,24 @@ namespace MsgViewer.Helpers
                 MoveAhead();
             tag = _html.Substring(start, _pos - start).ToLower();
 
-            // Parse rest of tag
-            while (!EndOfText && Peek() != '>')
+            if (tag.StartsWith("!--"))
             {
-                if (Peek() == '"' || Peek() == '\'')
-                    EatQuotedValue();
-                else
+                selfClosing = true;
+                EatComment();
+            }
+            else
+            {
+                // Parse rest of tag
+                while (!EndOfText && Peek() != '>')
                 {
-                    if (Peek() == '/')
-                        selfClosing = true;
-                    MoveAhead();
+                    if (Peek() == '"' || Peek() == '\'')
+                        EatQuotedValue();
+                    else
+                    {
+                        if (Peek() == '/')
+                            selfClosing = true;
+                        MoveAhead();
+                    }
                 }
             }
             MoveAhead();
@@ -342,6 +350,26 @@ namespace MsgViewer.Helpers
                 }
                 else
                     MoveAhead();
+            }
+        }
+        #endregion
+
+        #region EatComment
+        /// <summary>
+        /// Consumes inner content from an HTML comment
+        /// </summary>
+        /// <param name="tag"></param>
+        private void EatComment()
+        {
+            while (!EndOfText)
+            {
+                while (Peek() == '-')
+                {
+                    MoveAhead();
+                    if (Peek() == '>')
+                        return;
+                }
+                MoveAhead();
             }
         }
         #endregion


### PR DESCRIPTION
Hello,

A few months ago while working I have found a problem with the HtmlToText class.
I happened to get multiple stack overflow situations while trying to read some MSG files.
Those files were very large, but most importantly had a big HTML comment right at the start.

The reader didn't quite find the end of the comment tag (<!-- ... -->) as it was never marked as self closing due to not having a '/' when closing.
As the reading went on due to the large file size it resulted in a stack overflow exception looping the EatInnerContent method.

Unfortunately I can't show the original files due to them having sensitive information, and I didn't bother making another large enough file that also overflowed.
But I did realize that smaller files, while not overflowing, were not converted, and returned empty text.

I tested a bunch of situations, possible comment formats, with and without my change. Basically without my change any version of a comment would result in the rest of the HTML not being read.
Tested with the stack overflow huge files and the whole text content was returned with no problem.

I'm attaching below the console app I used to test with an example txt file with a comment.
It uses a copy of the class, just for convenience, feel free to open it and run it, debug it.
[MsgReaderStackOverflow.zip](https://github.com/Sicos1977/MSGReader/files/14186265/MsgReaderStackOverflow.zip)

Not claiming it's the best solution but it helped my work greatly 🤝
If you need more info, I'll do my best.