### PR TITLE
add icon index to message object

### DIFF
--- a/MsgReaderCore/Outlook/MapiTags.cs
+++ b/MsgReaderCore/Outlook/MapiTags.cs
@@ -450,6 +450,8 @@ internal static class MapiTags
     public const string PR_DELEGATION = "007E";
     public const string PR_TNEF_CORRELATION_KEY = "007F";
 
+    public const string PR_ICON_INDEX = "007F";
+
     /*
      *	Message content properties
      */

--- a/MsgReaderCore/Outlook/Message.cs
+++ b/MsgReaderCore/Outlook/Message.cs
@@ -1091,6 +1091,13 @@ public partial class Storage
             }
         }
 
+        public int IconIndex { 
+            get
+            {
+                return GetMapiPropertyInt32(MapiTags.PR_ICON_INDEX) ?? -1;
+            }
+        }
+
         // ReSharper disable once CSharpWarnings::CS0109
         /// <summary>
         ///     Returns a <see cref="Appointment" /> object when the <see cref="MessageType" /> is a
@@ -1551,6 +1558,9 @@ public partial class Storage
             Logger.WriteToLog("Loading storages and streams");
 
             base.LoadStorage(storage);
+
+            //identifier for icon index
+            //0x1080
 
             foreach (var storageStatistic in _subStorageStatistics)
                 // Run specific load method depending on sub storage name prefix


### PR DESCRIPTION
This PR adds the Icon_Index property to the message object that is available on the OutlookStorage.Message interop class.
I would need this property added in order to replace the Interop library with this one.