### PR TITLE
fix resource leak in Message.Load(FileInfo)

### DIFF
--- a/MsgReaderCore/Mime/Message.cs
+++ b/MsgReaderCore/Mime/Message.cs
@@ -579,7 +579,8 @@ public class Message
         if (!file.Exists)
             throw new FileNotFoundException("Cannot load message from non-existent file", file.FullName);
 
-        return Load(file.OpenRead());
+        using (var fileStream = file.OpenRead())
+            return Load(fileStream);
     }
 
     /// <summary>


### PR DESCRIPTION
The old code did not dispose the file stream opened by `file.OpenRead()` until the garbage collector caught it.  This change explicitly disposes the file stream and releases the file lock and the resources.