### PR TITLE
Headers may contain encoded and unencoded parts

### DIFF
--- a/MsgReaderCore/Mime/Decode/EncodedWord.cs
+++ b/MsgReaderCore/Mime/Decode/EncodedWord.cs
@@ -84,15 +84,16 @@ internal static class EncodedWord
         // var decodedWords = encodedWords;
         var decodedWords = string.Empty;
 
-        var matches = Regex.Matches(encodedWords, encodedWordRegex)
+        var matches = Regex.Matches(encodedWords, $"({encodedWordRegex})|(?<Unencoded>[^=]+)")
             .Cast<Match>()
             .Where(static m => m.Success)
             .Select(
                 static m => new {
                     m.Value,
-                    Content = m.Groups["Content"].Value,
+                    Content = m.Groups["Content"].Success ? m.Groups["Content"].Value : m.Groups["Unencoded"].Value,
                     Encoding = m.Groups["Encoding"].Value,
-                    Charset = m.Groups["Charset"].Value
+                    Charset = m.Groups["Charset"].Value,
+                    IsEncoded = m.Groups["Content"].Success
                 }
             )
             .ToList();
@@ -109,7 +110,8 @@ internal static class EncodedWord
             var tempContent = matches[i].Content;
             var tempEncoding = matches[i].Encoding;
             var tempCharset = matches[i].Charset;
-            
+            var isEncoded = matches[i].IsEncoded;
+
             // I believe most mailers handle the encoded word with the same encoding and charset,
             // however it's not specified on RFC 2047.
             // So, we need to check the encoding and the charset if they are different from the previous ones.
@@ -120,36 +122,44 @@ internal static class EncodedWord
             //     continue;
             // }
 
-            // Now it's time to decode the content
-            // Get the encoding which corresponds to the character set
-            var charsetEncoding = EncodingFinder.FindEncoding(tempCharset);
-
             // Store decoded text here when done
             string decodedText;
-            
-            // Encoding may also be written in lowercase
-            switch (tempEncoding.ToUpperInvariant())
+
+            if (isEncoded)
             {
-                // RFC:
-                // The "B" encoding is identical to the "BASE64" 
-                // encoding defined by RFC 2045.
-                // http://tools.ietf.org/html/rfc2045#section-6.8
-                case "B":
-                    decodedText = Base64.Decode(tempContent, charsetEncoding);
-                    break;
+                // Now it's time to decode the content
+                // Get the encoding which corresponds to the character set
+                var charsetEncoding = EncodingFinder.FindEncoding(tempCharset);
 
-                // RFC:
-                // The "Q" encoding is similar to the "Quoted-Printable" content-
-                // transfer-encoding defined in RFC 2045.
-                // There are more details to this. Please check
-                // http://tools.ietf.org/html/rfc2047#section-4.2
-                // 
-                case "Q":
-                    decodedText = QuotedPrintable.DecodeEncodedWord(tempContent, charsetEncoding);
-                    break;
+                // Encoding may also be written in lowercase
+                switch (tempEncoding.ToUpperInvariant())
+                {
+                    // RFC:
+                    // The "B" encoding is identical to the "BASE64" 
+                    // encoding defined by RFC 2045.
+                    // http://tools.ietf.org/html/rfc2045#section-6.8
+                    case "B":
+                        decodedText = Base64.Decode(tempContent, charsetEncoding);
+                        break;
 
-                default:
-                    throw new ArgumentException($"The encoding {tempEncoding} was not recognized");
+                    // RFC:
+                    // The "Q" encoding is similar to the "Quoted-Printable" content-
+                    // transfer-encoding defined in RFC 2045.
+                    // There are more details to this. Please check
+                    // http://tools.ietf.org/html/rfc2047#section-4.2
+                    // 
+                    case "Q":
+                        decodedText = QuotedPrintable.DecodeEncodedWord(tempContent, charsetEncoding);
+                        break;
+
+                    default:
+                        throw new ArgumentException($"The encoding {tempEncoding} was not recognized");
+                }
+            }
+            else
+            {
+                //If the value is not encoded, use the raw value
+                decodedText = tempValue;
             }
 
             // Replace our encoded value with our decoded value

--- a/MsgReaderTests/EncodingTests.cs
+++ b/MsgReaderTests/EncodingTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.IO;
+using MsgReader.Mime.Decode;
 
 namespace MsgReaderTests
 {
@@ -24,6 +25,29 @@ namespace MsgReaderTests
                 using var msg = new MsgReader.Outlook.Storage.Message(fileStream);
                 Assert.IsTrue(msg.Subject == "Un sujet très bien défini");
             }
+        }
+
+        [TestMethod]
+        public void From_ISO_8859_1()
+        {
+            using Stream fileStream = File.OpenRead(Path.Combine("SampleFiles", "EmailWithISO_8859_1_From.eml"));
+            var msg = new MsgReader.Mime.Message(fileStream);
+            Assert.IsTrue(msg.Headers.From.Address == "some@example.com");
+            Assert.IsTrue(msg.Headers.From.DisplayName == "Some ßtring");
+        }
+
+        [TestMethod]
+        public void Encoded_And_Unencoded()
+        {
+            var decoded = EncodedWord.Decode("=?iso-8859-1?Q?Some_=DFtring?= <some@example.com>");
+            Assert.IsTrue(decoded == "Some ßtring <some@example.com>");
+        }
+
+        [TestMethod]
+        public void Encoded_And_Unencoded_2()
+        {
+            var decoded = EncodedWord.Decode("=?iso-8859-1?Q?Some_=DFtring?= <some@example.com> =?iso-8859-1?Q?Some_=DFtring?=");
+            Assert.IsTrue(decoded == "Some ßtring <some@example.com> Some ßtring");
         }
     }
 }

--- a/MsgReaderTests/SampleFiles/EmailWithISO_8859_1_From.eml
+++ b/MsgReaderTests/SampleFiles/EmailWithISO_8859_1_From.eml
@@ -1,0 +1,10 @@
+Date: Tue, 28 Jan 2025 11:28:01 +0100
+MIME-Version: 1.0
+User-Agent: Mozilla Thunderbird
+Content-Language: en-US
+To: some@example.com
+From: =?iso-8859-1?Q?Some_=DFtring?= <some@example.com>"
+Subject: Test
+Content-Type: text/plain; charset=UTF-8; format=flowed
+Content-Transfer-Encoding: 7bit
+


### PR DESCRIPTION
EncodedWord.Decode dropped the unencoded part, leading to problems. Fix the parsing of encoded words to also include unencoded portions in the output.

Fixes #428