### PR TITLE
Update project file to support .NET 8.0 and 9.0

### DIFF
--- a/MsgReaderCore/MsgReader.csproj
+++ b/MsgReaderCore/MsgReader.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-    <TargetFrameworks>net462;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0;netstandard2.1;net8.0;net9.0</TargetFrameworks>
 		<RootNamespace>MsgReader</RootNamespace>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<Version>5.7.2</Version>
@@ -28,31 +28,43 @@ The EML reader supports MIME 1.0 encoded files.</Description>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="'$(TargetFramework)' != 'net462'">
+		<DefineConstants>$(DefineConstants);NETSTANDARD2_0_OR_GREATER</DefineConstants>
+	</PropertyGroup>
+
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
 		<DocumentationFile>MsgReader.xml</DocumentationFile>
 	</PropertyGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
-    <Reference Include="System" />
+		<PackageReference Include="System.Drawing.Common" Version="9.0.2" />
+		<PackageReference Include="System.Security.Cryptography.Pkcs" Version="9.0.2" />
+		<Reference Include="System" />
 		<Reference Include="System.Security" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'netstandard2.1'">
+		<PackageReference Include="Microsoft.Maui.Graphics" Version="8.0.100" />
+		<PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.1" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+		<PackageReference Include="Microsoft.Maui.Graphics" Version="8.0.100" />
+		<PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.1" />
+        <PackageReference Include="System.Formats.Asn1" Version="8.0.2" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+		<PackageReference Include="Microsoft.Maui.Graphics" Version="9.0.70" />
+		<PackageReference Include="System.Security.Cryptography.Pkcs" Version="9.0.2" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
-		<PackageReference Include="Microsoft.Maui.Graphics" Version="9.0.40" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="OpenMcdf" Version="2.4.1" />
 		<PackageReference Include="RtfPipe" Version="2.0.7677.4303" />
-		<PackageReference Include="System.Security.Cryptography.Pkcs" Version="9.0.2" />
 		<PackageReference Include="UTF.Unknown" Version="2.5.1" />
-	</ItemGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
-		<PackageReference Include="System.Drawing.Common" Version="9.0.2" />
-	</ItemGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net5' or '$(TargetFramework)' == 'net6' ">
-		<PackageReference Include="Microsoft.Maui.Graphics" Version="7.0.92" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/MsgReaderTests/MsgReaderTests.csproj
+++ b/MsgReaderTests/MsgReaderTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net5;net6;net7;net8</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <AssemblyVersion>3.3.0.0</AssemblyVersion>
     <FileVersion>1.3.0.0</FileVersion>


### PR DESCRIPTION
Hi,

So normally I would probably not touch the references but I'm trying to utilize your project in PowerShell 7.4 which is .NET 8 based. The project [Mailozaurr](https://github.com/EvotecIT/Mailozaurr) simplifies some mail related tasks for PowerShell users.

In theory with current settings including your project should work just fine, but after playing a lot I had to give up and change your project settings for it to pick it up properly. 

It was unable to load in PowerShell 7.4 (which is NET 8 based):
- System.Security.Cryptography.Pkcs 9.X.X
- System.Formats.Asn1 9.X.X

I did some reading and apparently it's possible that while most of the time new 9.X.X should work with NET 8.0 something forces PowerShell 7 to require older version. Probably internally it's dependant on other 8.X packages which require 8.X. 

I saw that MimeKit, MailKit also reference the 8.X.X versions so hope you wouldn't mind, but I actually did leave 9.0.2 for NET 4.6.2 and Net 9.0. 

I wasn't really sure if you want to keep NET 5, NET 6 support. Those are no longer supported since a while. But I could add them back if you wish. 

Btw. UTF tests are failing, I am not sure it's related to my changes, but wasn't able to fix them :-(

Przemek