### PR TITLE
Fix #443: Preserve time zone when parsing Date header from EML files

### DIFF
--- a/MsgReaderCore/Helpers/EmlDateParser.cs
+++ b/MsgReaderCore/Helpers/EmlDateParser.cs
@@ -1,0 +1,66 @@
+﻿//
+// EmlDateParser.cs
+//
+// Author: siemvanoers
+// 
+// Copyright (c) 2013-2025 Siem
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+// 
+
+using System;
+using System.Text.RegularExpressions;
+
+namespace MsgReader.Helpers
+
+/// <summary>
+///     Helper class for parsing the Date header from an EML file,
+///     preserving the time zone offset as specified in the header.
+/// </summary>
+{
+    public static class EmlDateParser
+    {
+        #region ParseDateHeader
+        /// <summary>
+        ///     Extracts and parses the Date header from the given EML content,
+        ///     preserving the time zone offset.
+        /// </summary>
+        /// <param name="emlContent">The raw EML content as a string.</param>
+        /// <returns>
+        ///     A <see cref="DateTimeOffset"/> representing the parsed date and time zone,
+        ///     or <c>null</c> if the Date header is not found or cannot be parsed.
+        /// </returns>
+        public static DateTimeOffset? ParseDateHeader(string emlContent)
+        {
+            // Extract the Date header (case-insensitive)
+            var match = Regex.Match(emlContent, @"^Date:\s*(.+)$", RegexOptions.Multiline | RegexOptions.IgnoreCase);
+            if (!match.Success)
+                return null;
+
+            var dateHeader = match.Groups[1].Value.Trim();
+
+            // Parse using DateTimeOffset to preserve the offset
+            if (DateTimeOffset.TryParse(dateHeader, out var parsedDate))
+                return parsedDate;
+
+            return null;
+        }
+        #endregion
+    }
+}

--- a/MsgReaderCore/Mime/Header/MessageHeader.cs
+++ b/MsgReaderCore/Mime/Header/MessageHeader.cs
@@ -417,8 +417,10 @@ public sealed class MessageHeader
             // See https://tools.ietf.org/html/rfc4021#section-2.1.48
             case "DELIVERY-DATE":
                 Date = headerValue.Trim();
-                var date = Rfc2822DateTime.StringToDate(headerValue);
-                DateSent = date != DateTime.MinValue ? date : DateTime.UtcNow;
+                //var date = Rfc2822DateTime.StringToDate(headerValue);
+                var parsed = MsgReader.Helpers.EmlDateParser.ParseDateHeader("Date: " + headerValue.Trim());
+                //DateSent = date != DateTime.MinValue ? date : DateTime.UtcNow;
+                DateSent = parsed ?? DateTimeOffset.UtcNow;
                 break;
 
             // See http://tools.ietf.org/html/rfc2045#section-6

--- a/MsgReaderTests/DateHeaderParsingTests.cs
+++ b/MsgReaderTests/DateHeaderParsingTests.cs
@@ -1,0 +1,89 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MsgReader.Mime.Header;
+using System.Diagnostics;
+
+namespace MsgReaderTests
+{
+    [TestClass]
+    public class DateHeaderParsingTests
+    {
+        [TestMethod]
+        public void DateHeader_WithTimeZone_IsParsedCorrectly()
+        {
+            // Arrange: sample EML content with a Date header
+            string eml = @"Date: Fri, 2 May 2025 12:27:25 +0000
+MIME-Version: 1.0
+To: some@example.com
+From: someone@example.com
+Subject: Test
+
+Body text.";
+
+            // Act: extract headers and parse
+            var headers = HeaderExtractor.GetHeaders(eml);
+
+            // Output the parsed result for verification
+            Debug.WriteLine("Parsed DateSent: " + headers.DateSent.ToString("o"));
+
+            // Assert: the DateSent should be in UTC (+0000)
+            Assert.AreEqual(2025, headers.DateSent.Year);
+            Assert.AreEqual(5, headers.DateSent.Month);
+            Assert.AreEqual(2, headers.DateSent.Day);
+            Assert.AreEqual(12, headers.DateSent.Hour);
+            Assert.AreEqual(0, headers.DateSent.Offset.Hours); // +0000
+        }
+
+        [TestMethod]
+        public void DateHeader_WithDifferentTimeZone_IsParsedCorrectly()
+        {
+            // Arrange: sample EML content with a Date header in +0200
+            string eml = @"Date: Fri, 2 May 2025 14:27:25 +0200
+MIME-Version: 1.0
+To: some@example.com
+From: someone@example.com
+Subject: Test
+
+Body text.";
+
+            // Act: extract headers and parse
+            var headers = HeaderExtractor.GetHeaders(eml);
+
+            // Output the parsed result for verification
+            System.Diagnostics.Debug.WriteLine("Parsed DateSent: " + headers.DateSent.ToString("o"));
+
+            // Assert: the DateSent should be in +0200
+            Assert.AreEqual(2025, headers.DateSent.Year);
+            Assert.AreEqual(5, headers.DateSent.Month);
+            Assert.AreEqual(2, headers.DateSent.Day);
+            Assert.AreEqual(14, headers.DateSent.Hour);
+            Assert.AreEqual(2, headers.DateSent.Offset.Hours); // +0200
+        }
+
+        [TestMethod]
+        public void DateHeader_WithNegativeTimeZone_IsParsedCorrectly()
+        {
+            // Arrange: sample EML content with a Date header in -0500
+            string eml = @"Date: Fri, 2 May 2025 07:27:25 -0500
+MIME-Version: 1.0
+To: some@example.com
+From: someone@example.com
+Subject: Test
+
+Body text.";
+
+            // Act: extract headers and parse
+            var headers = HeaderExtractor.GetHeaders(eml);
+
+            // Output the parsed result for verification
+            Debug.WriteLine("Parsed DateSent: " + headers.DateSent.ToString("o"));
+
+            // Assert: the DateSent should be in -0500
+            Assert.AreEqual(2025, headers.DateSent.Year);
+            Assert.AreEqual(5, headers.DateSent.Month);
+            Assert.AreEqual(2, headers.DateSent.Day);
+            Assert.AreEqual(7, headers.DateSent.Hour);
+            Assert.AreEqual(-5, headers.DateSent.Offset.Hours); // -0500
+        }
+    }
+
+}

--- a/MsgViewer/MsgViewer.csproj
+++ b/MsgViewer/MsgViewer.csproj
@@ -12,7 +12,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <UseVSHostingProcess>false</UseVSHostingProcess>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
This pull request introduces a new helper class for parsing EML date headers, updates the date parsing logic in the `MessageHeader` class, adds unit tests to ensure correct parsing of date headers with time zones, and modifies the project configuration for compatibility improvements.

### Date Parsing Enhancements:
* Added a new helper class `EmlDateParser` in `MsgReaderCore/Helpers/EmlDateParser.cs`. This class provides a `ParseDateHeader` method that extracts and parses the `Date` header from EML content, preserving the time zone offset.
* Updated the `ParseHeader` method in `MsgReaderCore/Mime/Header/MessageHeader.cs` to use the new `EmlDateParser.ParseDateHeader` method for parsing the `DELIVERY-DATE` header. The fallback behavior now defaults to `DateTimeOffset.UtcNow` when parsing fails.

### Unit Test Additions:
* Added `DateHeaderParsingTests` in `MsgReaderTests/DateHeaderParsingTests.cs` to validate the correct parsing of date headers with various time zones, including positive, negative, and UTC offsets.

### Project Configuration:
* Modified the `MsgViewer.csproj` file to change the build configuration condition from `Debug|x86` to `Debug|AnyCPU`, improving compatibility across different platforms.