### PR TITLE
Correction of the French "EmailSentOnLabel" translation

### DIFF
--- a/MsgReader/Localization/LanguageConsts.fr.resx
+++ b/MsgReader/Localization/LanguageConsts.fr.resx
@@ -348,7 +348,7 @@
     <value>De</value>
   </data>
   <data name="EmailSentOnLabel" xml:space="preserve">
-    <value>Envoyé par</value>
+    <value>Envoyé le</value>
   </data>
   <data name="EmailSignedBy" xml:space="preserve">
     <value>Signé par</value>


### PR DESCRIPTION
Bad translation (repers in [QuickLook](https://github.com/QL-Win/QuickLook) who use your library).

In French the value of "EmailSentOnLabel" should be "Envoyé le" to refer to a date, the actual value "Envoyé par" refers to people who send the email.