### PR TITLE
Fix issue with RTF/MELA header decoding

### DIFF
--- a/MsgReaderTests/RtfDecompressorTests.cs
+++ b/MsgReaderTests/RtfDecompressorTests.cs
@@ -1,6 +1,7 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System;
 using System.IO;
 using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MsgReader.Outlook;
 
 namespace MsgReaderTests
@@ -23,6 +24,46 @@ namespace MsgReaderTests
         {
             var rtf = RtfDecompressor.DecompressRtf(File.ReadAllBytes(Path.Combine("SampleFiles", "rtf", "MELA.bin")));
             Deal(Path.Combine("SampleFiles", "rtf", "MELA.rtf"), rtf);
+        }
+
+        /// <summary>
+        ///     Regression test for MELA-format RTF where uncompressedSize is set equal to
+        ///     compressedSize instead of the actual data length. Some MSG writers don't account
+        ///     for the 12-byte header overhead (RawSize + CompType + CRC) when setting
+        ///     uncompressedSize, causing it to exceed the available data by 12 bytes.
+        ///     Before the fix, DecompressRtf would silently return an all-zero byte array.
+        /// </summary>
+        [TestMethod]
+        public void MelaSizeMismatch()
+        {
+            // Build a dummy RTF payload
+            var rtfContent = Encoding.ASCII.GetBytes(
+                @"{\rtf1\ansi\ansicpg1252\deff0{\fonttbl{\f0\fswiss Helvetica;}}" +
+                @"\uc1\pard\plain\f0\fs20 Hello world.\par }");
+
+            // Build a MELA blob where uncompressedSize == compressedSize (the bug).
+            // Per MS-OXRTFCP, compressedSize includes the 12-byte overhead for the
+            // RawSize, CompType, and CRC fields. So compressedSize = rtfLen + 12.
+            // The bug: uncompressedSize is set to compressedSize (rtfLen + 12)
+            // instead of the actual data length (rtfLen). This means the decompressor
+            // tries to copy 12 more bytes than are available after the header.
+            var compressedSize = rtfContent.Length + 12;
+            var uncompressedSize = compressedSize; // BUG: should be rtfContent.Length
+
+            var blob = new byte[4 + compressedSize]; // 4 (compressedSize field) + compressedSize
+            BitConverter.GetBytes(compressedSize).CopyTo(blob, 0);
+            BitConverter.GetBytes(uncompressedSize).CopyTo(blob, 4);
+            BitConverter.GetBytes(0x414C454D).CopyTo(blob, 8); // MELA magic
+            BitConverter.GetBytes(0).CopyTo(blob, 12); // CRC (unused for MELA)
+            Array.Copy(rtfContent, 0, blob, 16, rtfContent.Length);
+
+            var result = RtfDecompressor.DecompressRtf(blob);
+
+            var resultString = Encoding.ASCII.GetString(result);
+            Assert.IsTrue(resultString.Contains(@"\rtf1"), "Decompressed output should contain valid RTF");
+            Assert.IsTrue(resultString.Contains("Hello world."), "Decompressed output should contain the body text");
+            Assert.AreEqual(rtfContent.Length, result.Length,
+                "Result length should match actual data, not the inflated uncompressedSize");
         }
 
         private static void Deal(string filePath, byte[] rtf)


### PR DESCRIPTION
We encountered an issue with malformed msg where the RTF is using MELA and the uncompressedSize wrongly includes the 12 bytes header offset.

Here's a fix that discard these additional 12 bytes when there's a size mismatch.

Symptoms: the conversion from MSG to HTML after calling `ExtractToFolder` leaves a blank body (the email headers are rendered, but not the actual email body).

Down-side: this might let through a bad RTF if there is actually 12 bytes missing (so when it's not an encoding issue). Not sure we can distinguish these cases at decompression stage.

Mitigation: eventually, the RTF parser should complain if the RTF source is malformed anyway.